### PR TITLE
feat(add): add --user flag to override the saved user/org

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ cd ghpending && git pull && cargo install --path .
 ## Usage
 
 ```sh
-ghpending add    # pick repos from a GitHub user/org to track
+ghpending add                # pick repos from the saved user/org to track
+ghpending add --user <name>  # switch to a different user/org (replaces the saved one)
 ghpending        # print the digest
 ghpending list   # show tracked repos
 ghpending rm     # remove repos from the list
 ```
 
-- `ghpending add` — prompts for a GitHub username or org, lists their public repos, and lets you select which ones to track. The username is saved so subsequent `add` runs skip the prompt.
+- `ghpending add` — prompts for a GitHub username or org, lists their public repos, and lets you select which ones to track. The username is saved so subsequent `add` runs skip the prompt. Pass `--user <name>` to switch to a different user/org without editing the config; it replaces the saved one.
 - `ghpending` — fetches all tracked repos concurrently and prints a digest of open issues and pull requests.
 - `ghpending list` — prints the repos currently in your watch list.
 - `ghpending rm` — opens an interactive menu to select repos to remove from tracking.
@@ -85,7 +86,7 @@ user = "akitaonrails"
 repos = ["ratatui-org/ratatui", "tokio-rs/tokio"]
 ```
 
-You can edit the file directly to change the `user` field or reorder repos.
+Run `ghpending add --user <name>` to change the `user` field, or edit the file directly to reorder repos.
 
 ## License
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,11 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Pick repos from a GitHub user/org to track
-    Add,
+    Add {
+        /// GitHub user/org to list repos from; replaces the saved one
+        #[arg(long)]
+        user: Option<String>,
+    },
     /// Remove repos from the watch list
     Rm,
     /// Print all tracked repos

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,20 +1,29 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use inquire::{MultiSelect, Text};
 use octocrab::Octocrab;
 
 use crate::{config, github};
 
-pub async fn run(crab: &Octocrab) -> Result<()> {
+pub async fn run(crab: &Octocrab, user: Option<String>) -> Result<()> {
     let mut cfg = config::load()?;
 
-    let username = if let Some(u) = cfg.user.clone() {
-        u
-    } else {
-        let u = Text::new("GitHub username or org to list repos from:").prompt()?;
-        let u = u.trim().to_string();
-        cfg.user = Some(u.clone());
-        config::save(&cfg)?;
-        u
+    let username = match resolve_user(user, cfg.user.clone()) {
+        UserChoice::Override(u) => {
+            cfg.user = Some(u.clone());
+            config::save(&cfg)?;
+            u
+        }
+        UserChoice::Saved(u) => u,
+        UserChoice::Prompt => {
+            let u = Text::new("GitHub username or org to list repos from:")
+                .prompt()?
+                .trim()
+                .to_owned();
+            cfg.user = Some(u.clone());
+            config::save(&cfg)?;
+            u
+        }
+        UserChoice::Blank => bail!("--user cannot be empty"),
     };
 
     let found = github::list_user_repos(crab, &username).await?;
@@ -51,4 +60,69 @@ pub async fn run(crab: &Octocrab) -> Result<()> {
     config::save(&cfg)?;
     println!("Saved. Tracking {} repo(s) total.", cfg.repos.len());
     Ok(())
+}
+
+/// Which GitHub user/org `add` should list repos from, decided from the
+/// optional `--user` flag and whatever is already saved in config.
+#[derive(Debug, PartialEq)]
+enum UserChoice {
+    /// `--user` was given: use it and persist it as the new saved default.
+    Override(String),
+    /// No flag, but config already holds a user: reuse it untouched.
+    Saved(String),
+    /// Neither flag nor saved user: prompt for one interactively.
+    Prompt,
+    /// `--user` was given but blank once trimmed.
+    Blank,
+}
+
+fn resolve_user(flag: Option<String>, saved: Option<String>) -> UserChoice {
+    match flag {
+        Some(u) => {
+            let u = u.trim();
+            if u.is_empty() {
+                UserChoice::Blank
+            } else {
+                UserChoice::Override(u.to_owned())
+            }
+        }
+        None => match saved {
+            Some(u) => UserChoice::Saved(u),
+            None => UserChoice::Prompt,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_overrides_saved_user() {
+        let choice = resolve_user(Some("octocat".into()), Some("akitaonrails".into()));
+        assert_eq!(choice, UserChoice::Override("octocat".into()));
+    }
+
+    #[test]
+    fn flag_is_trimmed() {
+        let choice = resolve_user(Some("  octocat  ".into()), None);
+        assert_eq!(choice, UserChoice::Override("octocat".into()));
+    }
+
+    #[test]
+    fn blank_flag_is_rejected_over_saved_user() {
+        let choice = resolve_user(Some("   ".into()), Some("akitaonrails".into()));
+        assert_eq!(choice, UserChoice::Blank);
+    }
+
+    #[test]
+    fn falls_back_to_saved_user_without_flag() {
+        let choice = resolve_user(None, Some("akitaonrails".into()));
+        assert_eq!(choice, UserChoice::Saved("akitaonrails".into()));
+    }
+
+    #[test]
+    fn prompts_when_nothing_supplied_or_saved() {
+        assert_eq!(resolve_user(None, None), UserChoice::Prompt);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     match &cli.command {
         Some(Commands::List) => commands::list::run()?,
         Some(Commands::Rm) => commands::remove::run()?,
-        Some(Commands::Add) => commands::add::run(&crab).await?,
+        Some(Commands::Add { user }) => commands::add::run(&crab, user.clone()).await?,
         None => commands::digest::run(&crab).await?,
     }
 


### PR DESCRIPTION
Closes #1.

## Problem

`ghpending add` saves the GitHub user/org to `config.toml` on first use and then always reuses it — there is no CLI way to switch to a different user/org without hand-editing the file.

## Change

Add an optional `--user <name>` flag to `add`:

- `ghpending add` — unchanged (uses the saved user, or prompts on first run).
- `ghpending add --user <name>` — uses that user/org and persists it as the new saved default.
- `ghpending add --user ""` — clear error (`--user cannot be empty`) instead of silently overwriting with a blank value.

## Implementation notes

Following the existing style, the decision is modeled as a small `enum UserChoice` resolved by a pure function `resolve_user(flag, saved)`, kept free of I/O so it is unit-tested directly (override / trim / blank / saved-fallback / prompt). README updated; the line that told users to hand-edit the config now points at the flag.

## Checks

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 34 passed (5 new)