### PR TITLE
feat(add): list private repos via --all and token-aware --user

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ cd ghpending && git pull && cargo install --path .
 ## Usage
 
 ```sh
-ghpending add    # pick repos from a GitHub user/org to track
+ghpending add                # pick repos from the saved user/org to track
+ghpending add --user <name>  # switch to a different user/org (replaces the saved one)
 ghpending        # print the digest
 ghpending list   # show tracked repos
 ghpending rm     # remove repos from the list
 ```
 
-- `ghpending add` — prompts for a GitHub username or org, lists their public repos, and lets you select which ones to track. The username is saved so subsequent `add` runs skip the prompt.
+- `ghpending add` — prompts for a GitHub username or org, lists their public repos, and lets you select which ones to track. The username is saved so subsequent `add` runs skip the prompt. Pass `--user <name>` to switch to a different user/org without editing the config; it replaces the saved one.
 - `ghpending` — fetches all tracked repos concurrently and prints a digest of open issues and pull requests.
 - `ghpending list` — prints the repos currently in your watch list.
 - `ghpending rm` — opens an interactive menu to select repos to remove from tracking.
@@ -85,7 +86,7 @@ user = "akitaonrails"
 repos = ["ratatui-org/ratatui", "tokio-rs/tokio"]
 ```
 
-You can edit the file directly to change the `user` field or reorder repos.
+Run `ghpending add --user <name>` to change the `user` field, or edit the file directly to reorder repos.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,15 @@ cd ghpending && git pull && cargo install --path .
 ```sh
 ghpending add                # pick repos from the saved user/org to track
 ghpending add --user <name>  # switch to a different user/org (replaces the saved one)
+ghpending add --all          # pick from every repo your token can reach (private included)
 ghpending        # print the digest
 ghpending list   # show tracked repos
 ghpending rm     # remove repos from the list
 ```
 
-- `ghpending add` — prompts for a GitHub username or org, lists their public repos, and lets you select which ones to track. The username is saved so subsequent `add` runs skip the prompt. Pass `--user <name>` to switch to a different user/org without editing the config; it replaces the saved one.
+- `ghpending add` — lists repos and lets you select which to track. The username is saved so subsequent `add` runs skip the prompt. Pass `--user <name>` to switch to a different user/org without editing the config; it replaces the saved one.
+  - **Private repos:** with a `GITHUB_TOKEN` that has the `repo` scope, `add` includes private repos automatically when the target is your own account or an org you belong to. For a third-party user only their public repos are visible.
+  - `--all` lists every repo your token can reach — owned, collaborator and organization-member, private included — in a single picker, ignoring the saved user. Use it to grab private repos you collaborate on across different owners.
 - `ghpending` — fetches all tracked repos concurrently and prints a digest of open issues and pull requests.
 - `ghpending list` — prints the repos currently in your watch list.
 - `ghpending rm` — opens an interactive menu to select repos to remove from tracking.
@@ -70,7 +73,7 @@ Everything works unauthenticated for public repos, subject to GitHub's default 6
 GITHUB_TOKEN=$(gh auth token) ghpending
 ```
 
-The token is read silently at startup — no configuration needed.
+The token is read silently at startup — no configuration needed. To track **private** repos (and have them show up in `ghpending add`), the token needs the `repo` scope (classic) or read access to the repo's Contents, Issues and Pull requests (fine-grained).
 
 ## Config
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,11 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Pick repos from a GitHub user/org to track
-    Add,
+    Add {
+        /// GitHub user/org to list repos from; replaces the saved one
+        #[arg(long)]
+        user: Option<String>,
+    },
     /// Remove repos from the watch list
     Rm,
     /// Print all tracked repos

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,9 +14,15 @@ pub struct Cli {
 pub enum Commands {
     /// Pick repos from a GitHub user/org to track
     Add {
-        /// GitHub user/org to list repos from; replaces the saved one
-        #[arg(long)]
+        /// GitHub user/org to list repos from; replaces the saved one.
+        /// Lists private repos too when it's your own account or an org you
+        /// belong to (needs a GITHUB_TOKEN with `repo` scope).
+        #[arg(long, conflicts_with = "all")]
         user: Option<String>,
+        /// List every repo your token can reach (owned, collaborator and
+        /// org-member), private included, ignoring the saved user.
+        #[arg(long)]
+        all: bool,
     },
     /// Remove repos from the watch list
     Rm,

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,20 +1,29 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use inquire::{MultiSelect, Text};
 use octocrab::Octocrab;
 
 use crate::{config, github};
 
-pub async fn run(crab: &Octocrab) -> Result<()> {
+pub async fn run(crab: &Octocrab, user: Option<String>) -> Result<()> {
     let mut cfg = config::load()?;
 
-    let username = if let Some(u) = cfg.user.clone() {
-        u
-    } else {
-        let u = Text::new("GitHub username or org to list repos from:").prompt()?;
-        let u = u.trim().to_string();
-        cfg.user = Some(u.clone());
-        config::save(&cfg)?;
-        u
+    let username = match resolve_user(user, cfg.user.clone()) {
+        UserChoice::Override(u) => {
+            cfg.user = Some(u.clone());
+            config::save(&cfg)?;
+            u
+        }
+        UserChoice::Saved(u) => u,
+        UserChoice::Prompt => {
+            let u = Text::new("GitHub username or org to list repos from:")
+                .prompt()?
+                .trim()
+                .to_owned();
+            cfg.user = Some(u.clone());
+            config::save(&cfg)?;
+            u
+        }
+        UserChoice::Blank => bail!("--user cannot be empty"),
     };
 
     let found = github::list_user_repos(crab, &username).await?;
@@ -51,4 +60,69 @@ pub async fn run(crab: &Octocrab) -> Result<()> {
     config::save(&cfg)?;
     println!("Saved. Tracking {} repo(s) total.", cfg.repos.len());
     Ok(())
+}
+
+/// Which GitHub user/org `add` should list repos from, decided from the
+/// optional `--user` flag and whatever is already saved in config.
+#[derive(Debug, PartialEq)]
+enum UserChoice {
+    /// `--user` was given: use it and persist it as the new saved default.
+    Override(String),
+    /// No flag, but config already holds a user: reuse it untouched.
+    Saved(String),
+    /// Neither flag nor saved user: prompt for one interactively.
+    Prompt,
+    /// `--user` was given but blank once trimmed.
+    Blank,
+}
+
+fn resolve_user(flag: Option<String>, saved: Option<String>) -> UserChoice {
+    match flag {
+        Some(u) => {
+            let u = u.trim();
+            if u.is_empty() {
+                UserChoice::Blank
+            } else {
+                UserChoice::Override(u.to_owned())
+            }
+        }
+        None => match saved {
+            Some(u) => UserChoice::Saved(u),
+            None => UserChoice::Prompt,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_overrides_saved_user() {
+        let choice = resolve_user(Some("octocat".into()), Some("akitaonrails".into()));
+        assert_eq!(choice, UserChoice::Override("octocat".into()));
+    }
+
+    #[test]
+    fn flag_is_trimmed() {
+        let choice = resolve_user(Some("  octocat  ".into()), None);
+        assert_eq!(choice, UserChoice::Override("octocat".into()));
+    }
+
+    #[test]
+    fn blank_flag_is_rejected_over_saved_user() {
+        let choice = resolve_user(Some("   ".into()), Some("akitaonrails".into()));
+        assert_eq!(choice, UserChoice::Blank);
+    }
+
+    #[test]
+    fn falls_back_to_saved_user_without_flag() {
+        let choice = resolve_user(None, Some("akitaonrails".into()));
+        assert_eq!(choice, UserChoice::Saved("akitaonrails".into()));
+    }
+
+    #[test]
+    fn prompts_when_nothing_supplied_or_saved() {
+        assert_eq!(resolve_user(None, None), UserChoice::Prompt);
+    }
 }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -2,33 +2,47 @@ use anyhow::{Result, bail};
 use inquire::{MultiSelect, Text};
 use octocrab::Octocrab;
 
+use crate::github::ListSource;
 use crate::{config, github};
 
-pub async fn run(crab: &Octocrab, user: Option<String>) -> Result<()> {
+pub async fn run(crab: &Octocrab, user: Option<String>, all: bool) -> Result<()> {
     let mut cfg = config::load()?;
 
-    let username = match resolve_user(user, cfg.user.clone()) {
-        UserChoice::Override(u) => {
-            cfg.user = Some(u.clone());
-            config::save(&cfg)?;
-            u
+    let found = if all {
+        github::list_authenticated_repos(crab).await?
+    } else {
+        let username = match resolve_user(user, cfg.user.clone()) {
+            UserChoice::Override(u) => {
+                cfg.user = Some(u.clone());
+                config::save(&cfg)?;
+                u
+            }
+            UserChoice::Saved(u) => u,
+            UserChoice::Prompt => {
+                let u = Text::new("GitHub username or org to list repos from:")
+                    .prompt()?
+                    .trim()
+                    .to_owned();
+                cfg.user = Some(u.clone());
+                config::save(&cfg)?;
+                u
+            }
+            UserChoice::Blank => bail!("--user cannot be empty"),
+        };
+
+        match github::resolve_source_for(crab, &username).await? {
+            ListSource::Authenticated => github::list_authenticated_repos(crab).await?,
+            ListSource::Org(org) => github::list_org_repos(crab, &org).await?,
+            ListSource::PublicUser(u) => github::list_user_repos(crab, &u).await?,
         }
-        UserChoice::Saved(u) => u,
-        UserChoice::Prompt => {
-            let u = Text::new("GitHub username or org to list repos from:")
-                .prompt()?
-                .trim()
-                .to_owned();
-            cfg.user = Some(u.clone());
-            config::save(&cfg)?;
-            u
-        }
-        UserChoice::Blank => bail!("--user cannot be empty"),
     };
 
-    let found = github::list_user_repos(crab, &username).await?;
     if found.is_empty() {
-        println!("No public repos found for: {username}");
+        if all {
+            println!("No repos found for your account.");
+        } else {
+            println!("No repos found.");
+        }
         return Ok(());
     }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -64,6 +64,62 @@ pub fn split_repo(s: &str) -> Option<(&str, &str)> {
     Some((owner, name))
 }
 
+/// Whether a GitHub account is a personal user or an organization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountKind {
+    User,
+    Organization,
+}
+
+/// Where `add` should pull the candidate repo list from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ListSource {
+    /// Everything the token can reach (owned + collaborator + org member),
+    /// private included. Used for `--all` and for listing your own account.
+    Authenticated,
+    /// A specific org's repos (private included when the token is a member).
+    Org(String),
+    /// A third-party user's public repos — all we can see for someone else.
+    PublicUser(String),
+}
+
+/// Maps the `type` field of a GitHub account profile to an `AccountKind`.
+/// Anything that is not exactly "Organization" is treated as a user.
+pub fn account_kind_from_type(profile_type: &str) -> AccountKind {
+    if profile_type == "Organization" {
+        AccountKind::Organization
+    } else {
+        AccountKind::User
+    }
+}
+
+/// Decides which `ListSource` `add` should use.
+///
+/// - `all`: the `--all` flag was passed.
+/// - `username`: the resolved target (`None` when `--all`).
+/// - `auth_login`: the login the token authenticates as.
+/// - `kind`: whether `username` is a user or org (`None` when `--all`).
+pub fn resolve_list_source(
+    all: bool,
+    username: Option<&str>,
+    auth_login: &str,
+    kind: Option<AccountKind>,
+) -> ListSource {
+    if all {
+        return ListSource::Authenticated;
+    }
+    let Some(username) = username else {
+        return ListSource::Authenticated;
+    };
+    if username.eq_ignore_ascii_case(auth_login) {
+        return ListSource::Authenticated;
+    }
+    match kind {
+        Some(AccountKind::Organization) => ListSource::Org(username.to_owned()),
+        _ => ListSource::PublicUser(username.to_owned()),
+    }
+}
+
 pub fn item_cmp(a: &RepoItem, b: &RepoItem) -> Ordering {
     match (&a.kind, &b.kind) {
         (ItemKind::PullRequest, ItemKind::Issue) => Ordering::Less,
@@ -90,6 +146,92 @@ pub async fn list_user_repos(crab: &Octocrab, username: &str) -> Result<Vec<Stri
     let mut names: Vec<String> = all_pages.into_iter().filter_map(|r| r.full_name).collect();
     names.sort();
     Ok(names)
+}
+
+/// Lists every repo the token can reach — owned, collaborator and
+/// organization-member, private included. Backs `add --all` and listing
+/// your own account.
+pub async fn list_authenticated_repos(crab: &Octocrab) -> Result<Vec<String>> {
+    let first_page = crab
+        .current()
+        .list_repos_for_authenticated_user()
+        .visibility("all")
+        .affiliation("owner,collaborator,organization_member")
+        .per_page(100)
+        .send()
+        .await
+        .context("listing repositories for the authenticated user")?;
+
+    let all_pages = crab
+        .all_pages(first_page)
+        .await
+        .context("paginating authenticated repositories")?;
+
+    let mut names: Vec<String> = all_pages.into_iter().filter_map(|r| r.full_name).collect();
+    names.sort();
+    names.dedup();
+    Ok(names)
+}
+
+/// Lists an org's repos, private included when the token is a member.
+pub async fn list_org_repos(crab: &Octocrab, org: &str) -> Result<Vec<String>> {
+    let first_page = crab
+        .orgs(org)
+        .list_repos()
+        .repo_type(octocrab::params::repos::Type::All)
+        .per_page(100)
+        .send()
+        .await
+        .context("listing organization repositories")?;
+
+    let all_pages = crab
+        .all_pages(first_page)
+        .await
+        .context("paginating organization repositories")?;
+
+    let mut names: Vec<String> = all_pages.into_iter().filter_map(|r| r.full_name).collect();
+    names.sort();
+    Ok(names)
+}
+
+/// The login the token authenticates as, or `None` when unauthenticated
+/// (no token / 401) so callers can fall back to public listing.
+pub async fn authenticated_login(crab: &Octocrab) -> Result<Option<String>> {
+    match crab.current().user().await {
+        Ok(user) => Ok(Some(user.login)),
+        Err(octocrab::Error::GitHub { source, .. }) if source.status_code.as_u16() == 401 => {
+            Ok(None)
+        }
+        Err(e) => Err(e).context("identifying the authenticated user"),
+    }
+}
+
+/// Whether `username` is a personal user or an organization.
+pub async fn account_kind(crab: &Octocrab, username: &str) -> Result<AccountKind> {
+    let profile = crab
+        .users(username)
+        .profile()
+        .await
+        .with_context(|| format!("fetching profile for {username}"))?;
+    Ok(account_kind_from_type(&profile.r#type))
+}
+
+/// Resolves which `ListSource` to use for a concrete target, querying GitHub
+/// for the authenticated login and the target's account kind as needed.
+pub async fn resolve_source_for(crab: &Octocrab, username: &str) -> Result<ListSource> {
+    let auth_login = authenticated_login(crab).await?;
+    if let Some(login) = &auth_login
+        && login.eq_ignore_ascii_case(username)
+    {
+        return Ok(ListSource::Authenticated);
+    }
+    let kind = account_kind(crab, username).await?;
+    Ok(resolve_list_source(
+        false,
+        Some(username),
+        auth_login.as_deref().unwrap_or(""),
+        Some(kind),
+    ))
 }
 
 pub async fn fetch_repo_items(crab: &Octocrab, repo: &str) -> RepoResult {
@@ -196,6 +338,64 @@ mod tests {
             created_at: Utc::now(),
             author: "user".into(),
         }
+    }
+
+    #[test]
+    fn account_kind_organization() {
+        assert_eq!(
+            account_kind_from_type("Organization"),
+            AccountKind::Organization
+        );
+    }
+
+    #[test]
+    fn account_kind_user() {
+        assert_eq!(account_kind_from_type("User"), AccountKind::User);
+    }
+
+    #[test]
+    fn account_kind_unknown_defaults_to_user() {
+        assert_eq!(account_kind_from_type("Bot"), AccountKind::User);
+    }
+
+    #[test]
+    fn all_flag_lists_authenticated() {
+        assert_eq!(
+            resolve_list_source(true, None, "me", None),
+            ListSource::Authenticated
+        );
+    }
+
+    #[test]
+    fn own_username_lists_authenticated() {
+        assert_eq!(
+            resolve_list_source(false, Some("me"), "me", Some(AccountKind::User)),
+            ListSource::Authenticated
+        );
+    }
+
+    #[test]
+    fn own_username_is_case_insensitive() {
+        assert_eq!(
+            resolve_list_source(false, Some("ME"), "me", Some(AccountKind::User)),
+            ListSource::Authenticated
+        );
+    }
+
+    #[test]
+    fn org_target_lists_org_repos() {
+        assert_eq!(
+            resolve_list_source(false, Some("acme"), "me", Some(AccountKind::Organization)),
+            ListSource::Org("acme".to_owned())
+        );
+    }
+
+    #[test]
+    fn third_party_user_lists_public_only() {
+        assert_eq!(
+            resolve_list_source(false, Some("octocat"), "me", Some(AccountKind::User)),
+            ListSource::PublicUser("octocat".to_owned())
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     match &cli.command {
         Some(Commands::List) => commands::list::run()?,
         Some(Commands::Rm) => commands::remove::run()?,
-        Some(Commands::Add { user }) => commands::add::run(&crab, user.clone()).await?,
+        Some(Commands::Add { user, all }) => commands::add::run(&crab, user.clone(), *all).await?,
         None => commands::digest::run(&crab).await?,
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     match &cli.command {
         Some(Commands::List) => commands::list::run()?,
         Some(Commands::Rm) => commands::remove::run()?,
-        Some(Commands::Add) => commands::add::run(&crab).await?,
+        Some(Commands::Add { user }) => commands::add::run(&crab, user.clone()).await?,
         None => commands::digest::run(&crab).await?,
     }
 


### PR DESCRIPTION
Closes #3.

> **Stacked on #2** (`feat(add): --user flag`). That branch is the base for this work, so until #2 lands this PR also shows its commit — review/merge #2 first and the diff here collapses to just the private-repo change.

## Problem

`ghpending add` discovers candidate repos through `github::list_user_repos`, which calls `GET /users/{username}/repos` with `type=Owner`. That endpoint only returns **public** repositories even with an authenticated token, so private repos never appear in the picker and the only way to track one is to hand-edit `config.toml`. (The digest itself already works on private repos once tracked — the gap is purely in *discovering* them.)

## Change

Make `add` token-aware so it surfaces the private repos the token can actually reach:

- `ghpending add --user <you>` → your own account via `GET /user/repos`, **private included**.
- `ghpending add --user <org>` → that org via `GET /orgs/{org}/repos`, **private included** when you are a member.
- `ghpending add --user <third-party>` → unchanged, public only (all GitHub exposes for someone else).
- `ghpending add --all` → every repo your token can reach (owned + collaborator + org-member), **private included**, in a single picker. Mutually exclusive with `--user`.

Requires a `GITHUB_TOKEN` with the `repo` scope. README updated.

## Implementation notes

Following the existing style, the source-selection decision is split from I/O:

- `account_kind_from_type(&str) -> AccountKind` and `resolve_list_source(all, username, auth_login, kind) -> ListSource` are pure functions, unit-tested directly (all-flag / own-account / case-insensitive / org / third-party).
- The network side (`list_authenticated_repos`, `list_org_repos`, `authenticated_login`, `account_kind`, `resolve_source_for`) mirrors the existing `list_user_repos` (paginated, `per_page(100)`, `Context` on errors). `authenticated_login` maps a 401 to `None` so an absent/unauthenticated token falls back to public listing instead of erroring.

## Checks

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 42 passed (8 new)
- `cargo build --release` — clean