### PR TITLE
Add opt-in subscription filtering and proportional digest limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ghpending"
 version = "0.4.2"
 edition = "2024"
-description = "CLI digest of subscribed open issues and pull requests across watched GitHub repos"
+description = "CLI digest of open issues and pull requests across watched GitHub repos"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/akitaonrails/ghpending"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ghpending"
 version = "0.4.2"
 edition = "2024"
-description = "CLI to watch GitHub repos for open issues and pull requests at a glance"
+description = "CLI digest of subscribed open issues and pull requests across watched GitHub repos"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/akitaonrails/ghpending"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ghpending
 
-See open issues and pull requests across the GitHub repos you care about, at a glance.
+See open issues and pull requests you are subscribed to across selected GitHub repos, at a glance.
 
 ![ghpending output](https://raw.githubusercontent.com/akitaonrails/ghpending/main/docs/screenshot.png)
 
@@ -71,19 +71,21 @@ ghpending rm     # remove repos from the list
 - `ghpending add` — lists repos and lets you select which to track. The username is saved so subsequent `add` runs skip the prompt. Pass `--user <name>` to switch to a different user/org without editing the config; it replaces the saved one.
   - **Private repos:** with a `GITHUB_TOKEN` that has the `repo` scope, `add` includes private repos automatically when the target is your own account or an org you belong to. For a third-party user only their public repos are visible.
   - `--all` lists every repo your token can reach — owned, collaborator and organization-member, private included — in a single picker, ignoring the saved user. Use it to grab private repos you collaborate on across different owners.
-- `ghpending` — fetches all tracked repos concurrently and prints a digest of open issues and pull requests.
+- `ghpending` — fetches tracked repos concurrently and prints only open issues and pull requests that the authenticated user is subscribed to.
 - `ghpending list` — prints the repos currently in your watch list.
 - `ghpending rm` — opens an interactive menu to select repos to remove from tracking.
 
-## Authentication (optional)
+## Authentication
 
-Everything works unauthenticated for public repos, subject to GitHub's default 60 requests/hour rate limit. Set `GITHUB_TOKEN` to raise that to 5,000 requests/hour:
+The digest requires `GITHUB_TOKEN` because GitHub subscriptions are user-specific:
 
 ```sh
 GITHUB_TOKEN=$(gh auth token) ghpending
 ```
 
-The token is read silently at startup — no configuration needed. To track **private** repos (and have them show up in `ghpending add`), the token needs the `repo` scope (classic) or read access to the repo's Contents, Issues and Pull requests (fine-grained).
+The token is read silently at startup. Public repository discovery with `ghpending add --user <name>` can still work without authentication, subject to GitHub's 60 requests/hour limit.
+
+To include **private** repos, the token needs the `repo` scope (classic) or read access to the repo's Contents, Issues and Pull requests (fine-grained). Authenticated requests have a 5,000 requests/hour limit.
 
 ### GitHub API proxy (optional)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ghpending
 
-See open issues and pull requests you are subscribed to across selected GitHub repos, at a glance.
+See open issues and pull requests across selected GitHub repos, at a glance.
 
 ![ghpending output](https://raw.githubusercontent.com/akitaonrails/ghpending/main/docs/screenshot.png)
 
@@ -65,6 +65,7 @@ ghpending add --user <name>  # switch to a different user/org (replaces the save
 ghpending add --all          # pick from every repo your token can reach (private included)
 ghpending        # print the digest
 ghpending --limit 20  # cap the digest at 20 items, distributed proportionally per repo
+ghpending --subscribed  # show only issues and PRs you are subscribed to
 ghpending list   # show tracked repos
 ghpending rm     # remove repos from the list
 ```
@@ -72,21 +73,25 @@ ghpending rm     # remove repos from the list
 - `ghpending add` — lists repos and lets you select which to track. The username is saved so subsequent `add` runs skip the prompt. Pass `--user <name>` to switch to a different user/org without editing the config; it replaces the saved one.
   - **Private repos:** with a `GITHUB_TOKEN` that has the `repo` scope, `add` includes private repos automatically when the target is your own account or an org you belong to. For a third-party user only their public repos are visible.
   - `--all` lists every repo your token can reach — owned, collaborator and organization-member, private included — in a single picker, ignoring the saved user. Use it to grab private repos you collaborate on across different owners.
-- `ghpending` — fetches tracked repos concurrently and prints only open issues and pull requests that the authenticated user is subscribed to. Pass `--limit <count>` to cap the total number of displayed items; each repository receives a proportional share while preserving its existing item order.
+- `ghpending` — fetches tracked repos concurrently and prints their open issues and pull requests. Pass `--subscribed` to show only items that the authenticated user is subscribed to. Pass `--limit <count>` to cap the total number of displayed items; each repository receives a proportional share while preserving its existing item order.
 - `ghpending list` — prints the repos currently in your watch list.
 - `ghpending rm` — opens an interactive menu to select repos to remove from tracking.
 
 ## Authentication
 
-The digest requires `GITHUB_TOKEN` because GitHub subscriptions are user-specific:
+`GITHUB_TOKEN` is optional. Without one, public repository access is subject to GitHub's 60 requests/hour limit. Set a token for a 5,000 requests/hour limit and access to private repositories:
 
 ```sh
 GITHUB_TOKEN=$(gh auth token) ghpending
 ```
 
-The token is read silently at startup. Public repository discovery with `ghpending add --user <name>` can still work without authentication, subject to GitHub's 60 requests/hour limit.
+The `--subscribed` filter requires a token because GitHub subscriptions are user-specific:
 
-To include **private** repos, the token needs the `repo` scope (classic) or read access to the repo's Contents, Issues and Pull requests (fine-grained). Authenticated requests have a 5,000 requests/hour limit.
+```sh
+GITHUB_TOKEN=$(gh auth token) ghpending --subscribed
+```
+
+To include **private** repos, the token needs the `repo` scope (classic) or read access to the repo's Contents, Issues and Pull requests (fine-grained). The token is read silently at startup.
 
 ### GitHub API proxy (optional)
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ ghpending add                # pick repos from the saved user/org to track
 ghpending add --user <name>  # switch to a different user/org (replaces the saved one)
 ghpending add --all          # pick from every repo your token can reach (private included)
 ghpending        # print the digest
+ghpending --limit 20  # cap the digest at 20 items, distributed proportionally per repo
 ghpending list   # show tracked repos
 ghpending rm     # remove repos from the list
 ```
@@ -71,7 +72,7 @@ ghpending rm     # remove repos from the list
 - `ghpending add` — lists repos and lets you select which to track. The username is saved so subsequent `add` runs skip the prompt. Pass `--user <name>` to switch to a different user/org without editing the config; it replaces the saved one.
   - **Private repos:** with a `GITHUB_TOKEN` that has the `repo` scope, `add` includes private repos automatically when the target is your own account or an org you belong to. For a third-party user only their public repos are visible.
   - `--all` lists every repo your token can reach — owned, collaborator and organization-member, private included — in a single picker, ignoring the saved user. Use it to grab private repos you collaborate on across different owners.
-- `ghpending` — fetches tracked repos concurrently and prints only open issues and pull requests that the authenticated user is subscribed to.
+- `ghpending` — fetches tracked repos concurrently and prints only open issues and pull requests that the authenticated user is subscribed to. Pass `--limit <count>` to cap the total number of displayed items; each repository receives a proportional share while preserving its existing item order.
 - `ghpending list` — prints the repos currently in your watch list.
 - `ghpending rm` — opens an interactive menu to select repos to remove from tracking.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,9 @@ pub struct Cli {
     /// Color theme (default, evangelion, nerv)
     #[arg(long, global = true)]
     pub theme: Option<String>,
+    /// Maximum items to show across all repos, allocated proportionally
+    #[arg(long, value_name = "COUNT")]
+    pub limit: Option<usize>,
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(
     name = "ghpending",
-    about = "Digest of open issues and PRs across watched repos"
+    about = "Digest of subscribed open issues and PRs across watched repos"
 )]
 pub struct Cli {
     #[command(subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(
     name = "ghpending",
-    about = "Digest of subscribed open issues and PRs across watched repos"
+    about = "Digest of open issues and PRs across watched repos"
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -14,6 +14,9 @@ pub struct Cli {
     /// Maximum items to show across all repos, allocated proportionally
     #[arg(long, value_name = "COUNT")]
     pub limit: Option<usize>,
+    /// Only show items you are subscribed to (requires GITHUB_TOKEN)
+    #[arg(long)]
+    pub subscribed: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/commands/digest.rs
+++ b/src/commands/digest.rs
@@ -13,7 +13,7 @@ use crate::{config, display, github};
 const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_CONCURRENT_FETCHES: usize = 4;
 
-pub async fn run(crab: &Octocrab, theme: &Theme) -> Result<()> {
+pub async fn run(crab: &Octocrab, theme: &Theme, limit: Option<usize>) -> Result<()> {
     let cfg = config::load()?;
 
     if cfg.repos.is_empty() {
@@ -45,7 +45,7 @@ pub async fn run(crab: &Octocrab, theme: &Theme) -> Result<()> {
 
     spinner.finish_and_clear();
 
-    let digest = display::render_digest(&results, theme);
+    let digest = display::render_digest(&results, theme, limit);
     print!("{digest}");
 
     if all_repo_fetches_failed(&results) {

--- a/src/commands/digest.rs
+++ b/src/commands/digest.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -13,7 +14,12 @@ use crate::{config, display, github};
 const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_CONCURRENT_FETCHES: usize = 4;
 
-pub async fn run(crab: &Octocrab, theme: &Theme, limit: Option<usize>) -> Result<()> {
+pub async fn run(
+    crab: &Octocrab,
+    theme: &Theme,
+    limit: Option<usize>,
+    subscribed_only: bool,
+) -> Result<()> {
     let cfg = config::load()?;
 
     if cfg.repos.is_empty() {
@@ -30,18 +36,26 @@ pub async fn run(crab: &Octocrab, theme: &Theme, limit: Option<usize>) -> Result
     spinner.set_message("Fetching…");
     spinner.enable_steady_tick(Duration::from_millis(100));
 
-    let subscribed = match timeout(FETCH_TIMEOUT, github::fetch_subscribed_items(crab)).await {
-        Ok(Ok(subscribed)) => subscribed,
-        Ok(Err(error)) => {
-            spinner.finish_and_clear();
-            return Err(error);
-        }
-        Err(_) => {
-            spinner.finish_and_clear();
-            anyhow::bail!("listing subscribed issues and pull requests timed out after 30s");
-        }
+    let subscribed = if subscribed_only {
+        Some(
+            match timeout(FETCH_TIMEOUT, github::fetch_subscribed_items(crab)).await {
+                Ok(Ok(subscribed)) => subscribed,
+                Ok(Err(error)) => {
+                    spinner.finish_and_clear();
+                    return Err(error);
+                }
+                Err(_) => {
+                    spinner.finish_and_clear();
+                    anyhow::bail!(
+                        "listing subscribed issues and pull requests timed out after 30s"
+                    );
+                }
+            },
+        )
+    } else {
+        None
     };
-    let results = fetch_repos(crab, &cfg.repos, &subscribed).await;
+    let results = fetch_repos(crab, &cfg.repos, subscribed.as_ref()).await;
 
     spinner.finish_and_clear();
 
@@ -58,15 +72,18 @@ pub async fn run(crab: &Octocrab, theme: &Theme, limit: Option<usize>) -> Result
 async fn fetch_repos(
     crab: &Octocrab,
     repos: &[String],
-    subscribed: &SubscribedItems,
+    subscribed: Option<&SubscribedItems>,
 ) -> Vec<RepoResult> {
+    let empty_subscriptions = HashSet::new();
     let mut results = vec![None; repos.len()];
     let mut in_flight = FuturesUnordered::new();
     let mut next = 0;
 
     while next < repos.len() && in_flight.len() < MAX_CONCURRENT_FETCHES {
         let repo = repos[next].clone();
-        let subscribed_numbers = subscribed.get(&repo.to_ascii_lowercase());
+        let repo_key = repo.to_ascii_lowercase();
+        let subscribed_numbers =
+            subscribed.map(|items| items.get(&repo_key).unwrap_or(&empty_subscriptions));
         in_flight.push(fetch_repo_with_timeout(
             crab,
             next,
@@ -87,7 +104,9 @@ async fn fetch_repos(
 
                 if next < repos.len() {
                     let repo = repos[next].clone();
-                    let subscribed_numbers = subscribed.get(&repo.to_ascii_lowercase());
+                    let repo_key = repo.to_ascii_lowercase();
+                    let subscribed_numbers = subscribed
+                        .map(|items| items.get(&repo_key).unwrap_or(&empty_subscriptions));
                     in_flight.push(fetch_repo_with_timeout(
                         crab,
                         next,

--- a/src/commands/digest.rs
+++ b/src/commands/digest.rs
@@ -6,7 +6,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use octocrab::Octocrab;
 use tokio::time::{self, timeout};
 
-use crate::github::{RepoError, RepoResult, RepoStatus};
+use crate::github::{RepoError, RepoResult, RepoStatus, SubscribedItems};
 use crate::theme::Theme;
 use crate::{config, display, github};
 
@@ -30,7 +30,18 @@ pub async fn run(crab: &Octocrab, theme: &Theme) -> Result<()> {
     spinner.set_message("Fetching…");
     spinner.enable_steady_tick(Duration::from_millis(100));
 
-    let results = fetch_repos(crab, &cfg.repos).await;
+    let subscribed = match timeout(FETCH_TIMEOUT, github::fetch_subscribed_items(crab)).await {
+        Ok(Ok(subscribed)) => subscribed,
+        Ok(Err(error)) => {
+            spinner.finish_and_clear();
+            return Err(error);
+        }
+        Err(_) => {
+            spinner.finish_and_clear();
+            anyhow::bail!("listing subscribed issues and pull requests timed out after 30s");
+        }
+    };
+    let results = fetch_repos(crab, &cfg.repos, &subscribed).await;
 
     spinner.finish_and_clear();
 
@@ -44,14 +55,24 @@ pub async fn run(crab: &Octocrab, theme: &Theme) -> Result<()> {
     Ok(())
 }
 
-async fn fetch_repos(crab: &Octocrab, repos: &[String]) -> Vec<RepoResult> {
+async fn fetch_repos(
+    crab: &Octocrab,
+    repos: &[String],
+    subscribed: &SubscribedItems,
+) -> Vec<RepoResult> {
     let mut results = vec![None; repos.len()];
     let mut in_flight = FuturesUnordered::new();
     let mut next = 0;
 
     while next < repos.len() && in_flight.len() < MAX_CONCURRENT_FETCHES {
         let repo = repos[next].clone();
-        in_flight.push(fetch_repo_with_timeout(crab, next, repo));
+        let subscribed_numbers = subscribed.get(&repo.to_ascii_lowercase());
+        in_flight.push(fetch_repo_with_timeout(
+            crab,
+            next,
+            repo,
+            subscribed_numbers,
+        ));
         next += 1;
     }
 
@@ -66,7 +87,13 @@ async fn fetch_repos(crab: &Octocrab, repos: &[String]) -> Vec<RepoResult> {
 
                 if next < repos.len() {
                     let repo = repos[next].clone();
-                    in_flight.push(fetch_repo_with_timeout(crab, next, repo));
+                    let subscribed_numbers = subscribed.get(&repo.to_ascii_lowercase());
+                    in_flight.push(fetch_repo_with_timeout(
+                        crab,
+                        next,
+                        repo,
+                        subscribed_numbers,
+                    ));
                     next += 1;
                 }
             }
@@ -84,8 +111,14 @@ async fn fetch_repo_with_timeout(
     crab: &Octocrab,
     index: usize,
     repo: String,
+    subscribed_numbers: Option<&std::collections::HashSet<u64>>,
 ) -> (usize, RepoResult) {
-    let result = match timeout(FETCH_TIMEOUT, github::fetch_repo_items(crab, &repo)).await {
+    let result = match timeout(
+        FETCH_TIMEOUT,
+        github::fetch_repo_items(crab, &repo, subscribed_numbers),
+    )
+    .await
+    {
         Ok(result) => result,
         Err(_) => timeout_result(repo),
     };

--- a/src/display.rs
+++ b/src/display.rs
@@ -22,14 +22,26 @@ fn paint(text: &str, color: bool, style: Style) -> String {
     }
 }
 
-pub fn render_digest(results: &[RepoResult], theme: &Theme) -> String {
-    render_inner(results, theme, should_colorize(), term_width())
+pub fn render_digest(results: &[RepoResult], theme: &Theme, limit: Option<usize>) -> String {
+    render_inner_limited(results, theme, should_colorize(), term_width(), limit)
 }
 
+#[cfg(test)]
 fn render_inner(results: &[RepoResult], theme: &Theme, color: bool, width: usize) -> String {
+    render_inner_limited(results, theme, color, width, None)
+}
+
+fn render_inner_limited(
+    results: &[RepoResult],
+    theme: &Theme,
+    color: bool,
+    width: usize,
+    limit: Option<usize>,
+) -> String {
     if results.is_empty() {
         return "No repos tracked. Run `ghpending add` to get started.\n".into();
     }
+    let item_allocations = allocate_items(results, limit);
 
     let now = Utc::now();
     let total = results.len();
@@ -45,8 +57,8 @@ fn render_inner(results: &[RepoResult], theme: &Theme, color: bool, width: usize
     let mut body = String::new();
     let mut shown = 0;
 
-    for result in results {
-        if matches!(&result.status, RepoStatus::Items(items) if items.is_empty()) {
+    for (index, result) in results.iter().enumerate() {
+        if matches!(&result.status, RepoStatus::Items(_)) && item_allocations[index] == 0 {
             continue;
         }
 
@@ -70,7 +82,7 @@ fn render_inner(results: &[RepoResult], theme: &Theme, color: bool, width: usize
             RepoStatus::Items(items) => {
                 let title_max = if width > 20 { width - 20 } else { 10 };
 
-                for item in items {
+                for item in items.iter().take(item_allocations[index]) {
                     let (kind_str, number_str, title_str) = match item.kind {
                         ItemKind::PullRequest => {
                             let ks = paint("PR ", color, theme.pr);
@@ -115,6 +127,43 @@ fn render_inner(results: &[RepoResult], theme: &Theme, color: bool, width: usize
     }
 }
 
+fn allocate_items(results: &[RepoResult], limit: Option<usize>) -> Vec<usize> {
+    let mut allocations = results
+        .iter()
+        .map(|result| match &result.status {
+            RepoStatus::Items(items) => items.len(),
+            _ => 0,
+        })
+        .collect::<Vec<_>>();
+    let total = allocations.iter().sum::<usize>();
+    let Some(limit) = limit else {
+        return allocations;
+    };
+    if total <= limit {
+        return allocations;
+    }
+
+    let mut remainders = Vec::new();
+    let mut allocated = 0;
+    for (index, allocation) in allocations.iter_mut().enumerate() {
+        if *allocation == 0 {
+            continue;
+        }
+        let numerator = *allocation as u128 * limit as u128;
+        *allocation = (numerator / total as u128) as usize;
+        allocated += *allocation;
+        remainders.push((index, numerator % total as u128));
+    }
+
+    remainders
+        .sort_unstable_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    for (index, _) in remainders.into_iter().take(limit - allocated) {
+        allocations[index] += 1;
+    }
+
+    allocations
+}
+
 fn pr_state_label(item: &crate::github::RepoItem) -> Option<&'static str> {
     match item.kind {
         ItemKind::PullRequest => match item.pr_draft {
@@ -153,6 +202,57 @@ mod tests {
             author: "testuser".into(),
             pr_draft: draft,
         }
+    }
+
+    #[test]
+    fn item_limit_is_proportional_without_distorting_summary() {
+        let results = vec![
+            RepoResult {
+                repo: "a/large".into(),
+                status: RepoStatus::Items(
+                    (1..=5)
+                        .map(|number| make_item(ItemKind::Issue, number, "large", 1))
+                        .collect(),
+                ),
+            },
+            RepoResult {
+                repo: "b/medium".into(),
+                status: RepoStatus::Items(
+                    (1..=3)
+                        .map(|number| make_item(ItemKind::Issue, number, "medium", 1))
+                        .collect(),
+                ),
+            },
+            RepoResult {
+                repo: "c/small".into(),
+                status: RepoStatus::Items(
+                    (1..=2)
+                        .map(|number| make_item(ItemKind::Issue, number, "small", 1))
+                        .collect(),
+                ),
+            },
+        ];
+
+        assert_eq!(allocate_items(&results, Some(6)), vec![3, 2, 1]);
+
+        let out = render_inner_limited(&results, &Theme::default_theme(), false, 80, Some(6));
+        assert_eq!(
+            out.lines().filter(|line| line.starts_with("  ISS")).count(),
+            6
+        );
+        assert!(out.contains("3 projects checked, 3 with pending tasks"));
+    }
+
+    #[test]
+    fn zero_item_limit_hides_items_but_preserves_summary() {
+        let results = vec![RepoResult {
+            repo: "a/repo".into(),
+            status: RepoStatus::Items(vec![make_item(ItemKind::Issue, 1, "issue", 1)]),
+        }];
+
+        let out = render_inner_limited(&results, &Theme::default_theme(), false, 80, Some(0));
+
+        assert_eq!(out, "1 projects checked, 1 with pending tasks\n");
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -394,7 +394,9 @@ async fn fetch_items_inner(
 }
 
 fn retain_subscribed(items: &mut Vec<RepoItem>, subscribed_numbers: Option<&HashSet<u64>>) {
-    items.retain(|item| subscribed_numbers.is_some_and(|numbers| numbers.contains(&item.number)));
+    if let Some(numbers) = subscribed_numbers {
+        items.retain(|item| numbers.contains(&item.number));
+    }
 }
 
 #[cfg(test)]
@@ -517,6 +519,18 @@ mod tests {
 
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].number, 7);
+    }
+
+    #[test]
+    fn missing_subscription_filter_keeps_all_repo_items() {
+        let mut items = vec![
+            make_item(ItemKind::Issue, 7),
+            make_item(ItemKind::PullRequest, 9),
+        ];
+
+        retain_subscribed(&mut items, None);
+
+        assert_eq!(items.len(), 2);
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,8 +1,10 @@
 use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use octocrab::Octocrab;
+use serde::Deserialize;
 use thiserror::Error;
 
 #[derive(Debug, Clone)]
@@ -20,6 +22,8 @@ pub enum ItemKind {
     PullRequest,
     Issue,
 }
+
+pub type SubscribedItems = HashMap<String, HashSet<u64>>;
 
 #[derive(Debug, Clone)]
 pub struct RepoResult {
@@ -243,7 +247,55 @@ pub async fn resolve_source_for(crab: &Octocrab, username: &str) -> Result<ListS
     ))
 }
 
-pub async fn fetch_repo_items(crab: &Octocrab, repo: &str) -> RepoResult {
+#[derive(Debug, Deserialize)]
+struct SubscribedIssue {
+    number: u64,
+    repository_url: String,
+}
+
+pub async fn fetch_subscribed_items(crab: &Octocrab) -> Result<SubscribedItems> {
+    let first_page = crab
+        .get::<octocrab::Page<SubscribedIssue>, _, _>(
+            "/issues?filter=subscribed&state=open&per_page=100",
+            None::<&()>,
+        )
+        .await
+        .context("listing subscribed issues and pull requests (GITHUB_TOKEN is required)")?;
+    let issues = crab
+        .all_pages(first_page)
+        .await
+        .context("paginating subscribed issues and pull requests")?;
+
+    Ok(index_subscribed_items(issues))
+}
+
+fn index_subscribed_items(issues: Vec<SubscribedIssue>) -> SubscribedItems {
+    let mut subscribed = SubscribedItems::new();
+    for issue in issues {
+        let Some(repo) = repo_name_from_api_url(&issue.repository_url) else {
+            continue;
+        };
+        subscribed.entry(repo).or_default().insert(issue.number);
+    }
+    subscribed
+}
+
+fn repo_name_from_api_url(url: &str) -> Option<String> {
+    let (_, path) = url.split_once("/repos/")?;
+    let mut segments = path.split('/');
+    let owner = segments.next()?;
+    let name = segments.next()?;
+    if owner.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(format!("{owner}/{name}").to_ascii_lowercase())
+}
+
+pub async fn fetch_repo_items(
+    crab: &Octocrab,
+    repo: &str,
+    subscribed_numbers: Option<&HashSet<u64>>,
+) -> RepoResult {
     let Some((owner, name)) = split_repo(repo) else {
         return RepoResult {
             repo: repo.to_owned(),
@@ -251,7 +303,7 @@ pub async fn fetch_repo_items(crab: &Octocrab, repo: &str) -> RepoResult {
         };
     };
 
-    match fetch_items_inner(crab, owner, name).await {
+    match fetch_items_inner(crab, owner, name, subscribed_numbers).await {
         Ok(items) => RepoResult {
             repo: repo.to_owned(),
             status: RepoStatus::Items(items),
@@ -271,6 +323,7 @@ async fn fetch_items_inner(
     crab: &Octocrab,
     owner: &str,
     name: &str,
+    subscribed_numbers: Option<&HashSet<u64>>,
 ) -> std::result::Result<Vec<RepoItem>, GithubError> {
     let label = format!("{owner}/{name}");
 
@@ -332,10 +385,16 @@ async fn fetch_items_inner(
         });
     }
 
+    retain_subscribed(&mut items, subscribed_numbers);
+
     // Sort: PRs first, then issues; within each group by number descending
     items.sort_by(item_cmp);
 
     Ok(items)
+}
+
+fn retain_subscribed(items: &mut Vec<RepoItem>, subscribed_numbers: Option<&HashSet<u64>>) {
+    items.retain(|item| subscribed_numbers.is_some_and(|numbers| numbers.contains(&item.number)));
 }
 
 #[cfg(test)]
@@ -435,6 +494,29 @@ mod tests {
     fn split_repo_many_slashes() {
         // splitn(2) gives ("a", "b/c") — name contains a slash, which is fine
         assert_eq!(split_repo("a/b/c"), Some(("a", "b/c")));
+    }
+
+    #[test]
+    fn subscribed_index_and_filter_keep_only_matching_repo_items() {
+        let subscribed = index_subscribed_items(vec![
+            SubscribedIssue {
+                number: 7,
+                repository_url: "https://api.github.com/repos/Acme/Widget".into(),
+            },
+            SubscribedIssue {
+                number: 99,
+                repository_url: "https://api.github.com/users/octocat".into(),
+            },
+        ]);
+        let mut items = vec![
+            make_item(ItemKind::Issue, 7),
+            make_item(ItemKind::PullRequest, 9),
+        ];
+
+        retain_subscribed(&mut items, subscribed.get("acme/widget"));
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].number, 7);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,9 @@ async fn main() -> Result<()> {
     if cli.limit.is_some() && cli.command.is_some() {
         bail!("--limit can only be used when rendering the digest");
     }
+    if cli.subscribed && cli.command.is_some() {
+        bail!("--subscribed can only be used when rendering the digest");
+    }
 
     let cfg = config::load()?;
 
@@ -44,7 +47,7 @@ async fn main() -> Result<()> {
         Some(Commands::List) => commands::list::run()?,
         Some(Commands::Rm) => commands::remove::run()?,
         Some(Commands::Add { user, all }) => commands::add::run(&crab, user.clone(), *all).await?,
-        None => commands::digest::run(&crab, &resolved_theme, cli.limit).await?,
+        None => commands::digest::run(&crab, &resolved_theme, cli.limit, cli.subscribed).await?,
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@ use theme::Theme;
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
+    if cli.limit.is_some() && cli.command.is_some() {
+        bail!("--limit can only be used when rendering the digest");
+    }
 
     let cfg = config::load()?;
 
@@ -41,7 +44,7 @@ async fn main() -> Result<()> {
         Some(Commands::List) => commands::list::run()?,
         Some(Commands::Rm) => commands::remove::run()?,
         Some(Commands::Add { user, all }) => commands::add::run(&crab, user.clone(), *all).await?,
-        None => commands::digest::run(&crab, &resolved_theme).await?,
+        None => commands::digest::run(&crab, &resolved_theme, cli.limit).await?,
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- Add `--subscribed` to show only issues and pull requests the authenticated user is subscribed to.
- Keep the existing default behavior unchanged: without `--subscribed`, the digest shows all open items and `GITHUB_TOKEN` remains optional.
- Add `--limit <COUNT>` to cap the total number of displayed items across all tracked repositories.
- Distribute the limit proportionally between repositories using largest-remainder allocation.
- Preserve the existing PR-first ordering within each repository.
- Keep the summary based on the complete result set, rather than the truncated display.
- Update CLI help and README usage and authentication guidance.

## Motivation

`ghpending` is useful as a compact status widget in tools such as `clock-tui`, but repositories with many open items can produce more output than the widget can display.

The proportional limit keeps the digest within a fixed size without allowing one large repository to consume the entire output.

Subscription filtering provides a more focused view for users who only want threads they follow. It is opt-in so existing unauthenticated and public-repository workflows continue to work unchanged.

## Usage

Show all open items, with no token required for public repositories:

```sh
ghpending --limit 15
```

Show only items the authenticated user is subscribed to:

```sh
GITHUB_TOKEN=$(gh auth token) ghpending --subscribed --limit 15
```

## Implementation

Subscribed issue and pull request numbers are loaded from GitHub's authenticated global issues endpoint and intersected with each tracked repository's existing results. The repository fetch remains responsible for the full item metadata, including pull request draft state and existing sorting.

The display limit is applied only while rendering. This ensures the summary still reports the actual number of repositories with pending work.

## Verification

- `cargo test`: 72 tests passed.
- Verified that the default digest runs without `GITHUB_TOKEN`.
- Verified that `--subscribed` requires authentication.
- Verified that `--limit 5` renders exactly five items while retaining the complete summary.
- Verified the combined `--subscribed --limit 5` behavior against the live GitHub API.